### PR TITLE
feature/default-uncertainty_fieldname-value

### DIFF
--- a/SPECS.md
+++ b/SPECS.md
@@ -8,8 +8,8 @@ Designed to be used with `fn-prevalence-predictor`.
 
 A nested JSON object containing:
 - `point_data` - {GeoJSON FeatureCollection} Required.
-- `uncertainty_fieldname` - name of properties field which contains uncertainty value
-- `batch_size` - {integer} Representing the number of locations to adaptively sample. Defaults to 1.
+- `uncertainty_fieldname` - {string} Optional. Name of properties field which contains uncertainty value. Defaults to 'exceedance_uncertainty'.
+- `batch_size` - {integer} Optional. Number of locations to adaptively sample. Defaults to 1.
 
 The value of the `uncertainty_fieldname` can be zero or NA, but those points will be excluded from the sample. The batch size cannot be larger than the number of points with an uncertainty value greater than zero.
 

--- a/fn-adaptive-sampling/function/preprocess_params.R
+++ b/fn-adaptive-sampling/function/preprocess_params.R
@@ -21,8 +21,9 @@ function(params) {
     stop('Missing required `point_data` parameter')
   }
 
+  # Default value for uncertainty_fieldname
   if (is.null(params[['uncertainty_fieldname']])) {
-    stop('Mising required `uncertainty_fieldname` parameter')
+    params[['uncertainty_fieldname']] = 'exceedance_uncertainty'
   }
 
   point_data = st_read(as.json(params[['point_data']]), quiet=T)


### PR DESCRIPTION
Suggesting to select one of the output fields from fn-prev-pred to use as default here. Is this going to be too confusing? It just makes testing and demos simpler, if we can set one fewer field - i.e. we only need to send in `point_data`, and the rest have sensible defaults.